### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,6 +35,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   private
 
   def item_params

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
   <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
   
   <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
@@ -101,7 +101,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 


### PR DESCRIPTION
What（どのような実装をしたのか）

	•	商品削除機能を実装しました。
	•	出品者本人のみが、商品の詳細ページから商品を削除できるように設定しました。
	•	商品が削除されると、トップページへリダイレクトされる仕様にしました。
Why（なぜこの実装が必要なのか）

	•	商品の削除機能は、出品者が誤った商品情報を登録した場合や出品を取り消したい場合に対応するために必要です。
	•	出品者以外が削除できない仕様にすることで、不正な操作を防ぐためです。